### PR TITLE
fixed routing bug that was giving hydration and pre-render errors

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -42,6 +42,8 @@ const Dashboard: React.FC = () => {
 
   // Check if there is better fix for this.
   const [isNav, setIsNav] = useState(false);
+  
+  const [isClient, setIsClient] = useState(false);
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedItemIndex, setSelectedItemIndex] = useState<number | null>(null);
@@ -113,9 +115,17 @@ const Dashboard: React.FC = () => {
 
   useEffect(() => {
     setIsNav(true);
+    setIsClient(true); // indicate that client has been rendered
     getEligibleBids(); // get all eligible bids when page renders
     setPreviousBids(); // set bids in bidding table when page renders
   }, [])
+
+  //If not authorised, then redirects the user
+  useEffect(() => {
+    if (user == null) {
+        route.push('/');
+    }
+  }, [user, route]);
 
   const openModal = (index: number) => {
     setSelectedItemIndex(index);
@@ -127,15 +137,10 @@ const Dashboard: React.FC = () => {
     setIsModalOpen(false);
   };
 
-  //If not authorised, then redirects the user
-
-  if (user == null) {
-    route.push('/');
-  }
 
 
   return (
-    user == null ? (<div>Loading...</div>) : 
+    !isClient || user == null ? (<div>Loading...</div>) : 
     (<div className="h-screen w-full flex flex-col lg:flex-row">
       { isNav && <NavBar/>}
       <div className="flex-1 p-5 light:bg-white-800 text-black">

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -21,11 +21,22 @@ const ProfilePage = () => {
 
   const dispatch = useDispatch();
 
+  const [isClient, setIsClient] = useState(false);
   const [isNav, setIsNav] = useState(false);
 
   useEffect(() => {
     setIsNav(true);
   }, [])
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  useEffect(() => {
+    if (user == null) {
+        route.push('/');
+    }
+  }, [user, route]);
 
 
   const logout = () => {
@@ -34,13 +45,8 @@ const ProfilePage = () => {
   }
 
 
-  if (user == null) {
-    route.push('/');
-  }
-
-
   return (
-    user == null ? <div>Loading...</div> : 
+    !isClient || user == null ? <div>Loading...</div> : 
     <div className="bg-gradient-to-tl from-slate-200 to-slate-300 min-h-screen w-full flex flex-col lg:flex-row">
       { isNav && <NavBar/> }
       <main className="bg-gradient-to-tl from-slate-200 to-slate-300 h-fit w-full">


### PR DESCRIPTION
```
if (user == null) {
    route.push('/');
}
```
The errors stemmed from the above chunk of code in the dashboard and profile page.tsx files that was responsible for routing the user back to the login screen if they are unauthenticated

While there were no visible issues when running the app on dev, errors would occur when running `npm run build`:
> Error occurred prerendering page "/dashboard". Read more: https://nextjs.org/docs/messages/prerender-error
> ReferenceError: location is not defined

This could be because (according to GPT4) when Next.js tries to prerender the code, it is done on the server side, and there is no `location` object. A workaround was to add `useEffect` so that the code only runs on the client side
```
useEffect(() => {
    if (user == null) {
        route.push('/');
    }
}, [user, route]);
```

However, this created new issues on dev when the dashboard page was reloaded:
> Warning: An error occurred during hydration. The server HTML was replaced with client content in <#document>.
> Uncaught Error: Hydration failed because the initial UI does not match what was rendered on the server.

As per the error message, the hydration error occured due to a mismatch between what was rendered on the server and what was rendered on the client. This could be due to differences in the `user` state. 

The workaround that was implemented was to let both server and client render a placeholder first, and then change the client-side content after hydration. This was done with the following code additions / changes:
```
const [isClient, setIsClient] = useState(false);

// other code...

useEffect(() => {
    setIsClient(true);
}, []);

// other code...

useEffect(() => {
    if (user == null) {
        route.push('/');
    }
}, [user, route]);

// other code...

return (
    !isClient || user == null ? (<div>Loading...</div>) :
    // the rest of the component
```
This way, both the server and the client will initially render the "Loading..." content. Then, once the client-side hydration is complete and the effect runs, the state will update, and the rest of your component will render, replacing the "Loading..." content.

So far this has not caused any new issues on dev and during `npm run build`